### PR TITLE
Fix `stack` installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,7 @@ cabal install gitHUD
 
 ### With stack
 
-Create the following `stack.yaml` in your current directory:
-
-```yaml
-resolver: lts-5.0
-packages: []
-```
-
-... then install the executable by running:
+You can install the `stack` build tool from [haskellstack.com](http://haskellstack.com/) and then install the `gitHUD` executable by running:
 
 ```bash
 $ stack install --install-ghc gitHUD

--- a/README.md
+++ b/README.md
@@ -65,19 +65,17 @@ cabal install gitHUD
 
 ### With stack
 
-gitHUD is available on hackage, but not in the stack list of curated packages.
-to install it with stack, you need to add it to the extra-deps in your
-stack.yml file
+Create the following `stack.yaml` in your current directory:
 
-``` stack.yaml
-extra-deps:
-- gitHUD-1.0.0.0
+```yaml
+resolver: lts-5.0
+packages: []
 ```
 
-then you can run
+... then install the executable by running:
 
-```
-stack install gitHUD
+```bash
+$ stack install --install-ghc gitHUD
 ```
 
 ### From sources


### PR DESCRIPTION
There were a few small corrections to the `stack` instructions:

* Specify a `resolver` so that the build is reproducible
* There is no need to specify the package in the `extra-deps` section.  `stack` lets you install any package as long as its dependencies are on Stackage
* Specify `packages: []`.  `stack` assumes that the `packages` field is `.` by default, which means that the current directory must be a Haskell source project.  Setting this to the empty list means that the current build requires no source dependencies.