### PR TITLE
Switch to nix developPackage for haskell dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@
 # Copy these contents into the root directory of your Github project in a file
 # named .travis.yml
 language: nix
-script: nix-shell --run "cabal v2-update; cabal v2-test --enable-tests"
+script: nix-build

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,8 @@ with import (fetchTarball {
    url = https://github.com/nixos/nixpkgs/archive/beff2f8d75e.tar.gz;
    sha256 = "1av1m2mibv9dgfrjv9r8n3ih9dyb0wi594s5xb4c135v121jpzs3";
 }) {};
-mkShell {
-    buildInputs = [ pkgs.ghc ];
+
+haskellPackages.developPackage {
+  root = ./.;
+  name = "githud";
 }

--- a/githud.cabal
+++ b/githud.cabal
@@ -51,7 +51,7 @@ test-suite githud-test
   hs-source-dirs:     test
   main-is:            Spec.hs
   build-depends:      base
-                    , tasty >= 1.1.0 && < 1.2
+                    , tasty >= 1.1.0 && < 1.3
                     , tasty-hunit >= 0.10 && < 0.11
                     , tasty-smallcheck >= 0.8 && < 0.9
                     , tasty-quickcheck >= 0.10 && < 0.11


### PR DESCRIPTION
With `developPackage`, nix reads the cabal file and populate the
haskell package database with the required packages already existing
in nixpkgs.

Cabal read the "global" package database before trying to download /
install anything. If satisfying packages exists in the global
database, it won't fetch / build them.

The direct result of this change is that all haskell dependencies of
the project are fetched and cached by nix, meaning a faster startup of
the build.
Another interesting result is that haskell dependencies are fixed and reproducible. It was not the case with the previous version which was relying on the current hackage database and on the result of the cabal dependency resolution algorithm.

I've also made the following related changes:

- `shell.nix` renamed to `default.nix`. This does not change the
  behavior of `nix-shell`, but `nix-build` can work without command
  line argument. Hence `.travis.yml` is now simpler because the
  package can be built with `nix-build`.
- The bound for tasty was changed to `< 1.3` (was `< 1.2`) to allow
  the build with `tasty-1.2` which is the version in the selected
  nixpkgs clone.