### PR TITLE
Fix compatibility with unix version and allow newer daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You need to add the following to the extra-deps in your stack.yml file
 
 ``` ./.stack/global-project/stack.yaml
 extra-deps:
-- daemons-0.3.0
+- daemons-0.4.0
 - network-2.8.0.1
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
                 hfinal.callCabal2nix "githud" src { };
             };
         };
-        githud = final.haskell.lib.justStaticExecutables final.haskellPackages.githud;
+        githud = final.haskell.lib.justStaticExecutables final.haskell.packages.ghc96.githud;
       };
     in
     {

--- a/githud.cabal
+++ b/githud.cabal
@@ -35,7 +35,7 @@ library
                     , GitHUD.Types
   build-depends:      base >= 4.11 && < 5
                     , bytestring >= 0.10 && < 0.12
-                    , daemons >= 0.3 && < 0.4
+                    , daemons >= 0.3 && < 0.5
                     , data-default >= 0.7 && < 0.8
                     , directory >= 1.3 && < 1.4
                     , filelock >= 0.1.1.4 && < 0.1.2.0
@@ -74,7 +74,7 @@ test-suite githud-test
                     , tasty-hunit >= 0.10 && < 0.11
                     , tasty-smallcheck >= 0.8 && < 0.9
                     , tasty-quickcheck >= 0.10 && < 0.11
-                    , daemons >= 0.3 && < 0.4
+                    , daemons >= 0.3 && < 0.5
                     , parsec >= 3.1.13 && < 4
                     , mtl >= 2.2.2 && < 3
                     , githud

--- a/src/GitHUD.hs
+++ b/src/GitHUD.hs
@@ -22,7 +22,7 @@ import System.Environment (getArgs)
 import System.Exit (ExitCode (ExitSuccess))
 import System.FileLock (SharedExclusive (Exclusive), withTryFileLock)
 import System.Posix.Files (fileExist)
-import System.Posix.User (UserEntry (..), getRealUserID, getUserEntryForID)
+import System.Posix.User (getRealUserID, getUserEntryForID, homeDirectory)
 import System.Process (readProcessWithExitCode)
 
 githud :: IO ()


### PR DESCRIPTION
unix broke us in 2.8.0.0 https://github.com/haskell/unix/commit/7681b0efda4e1997a6d34295600de379f3aec464

daemons 0.4.0.0 is currently marked broken in nixpkgs because it requires ghc96 now, but I'll address that next