### PR TITLE
Update nixpkgs now that NixOS/nixpkgs#264934 is merged

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693985761,
-        "narHash": "sha256-K5b+7j7Tt3+AqbWkcw+wMeqOAWyCD1MH26FPZyWXpdo=",
+        "lastModified": 1700214285,
+        "narHash": "sha256-KVO8PSTYqkv9zDllar0vAqDy3RXXmJ1zNpOxfWlUqnE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
+        "rev": "6769eec801ed1c10b0ed3b7541e693161a8b7c26",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "githud flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -22,7 +22,7 @@
                 hfinal.callCabal2nix "githud" src { };
             };
         };
-        githud = final.haskell.lib.justStaticExecutables final.haskell.packages.ghc96.githud;
+        githud = final.haskell.lib.justStaticExecutables final.haskellPackages.githud;
       };
     in
     {
@@ -38,9 +38,9 @@
         packages.default = pkgs.githud;
         devShells.default = pkgs.mkShell {
           buildInputs = [
-              (pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.ghcid)
-              (pkgs.cabal-install)
-            ];
+            (pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.ghcid)
+            (pkgs.cabal-install)
+          ];
           inputsFrom = [ self.packages.${system}.default.env ];
         };
       });


### PR DESCRIPTION
Not that daemons 0.3.0.0 is actually broken on ghc9.6 so we're building with the default ghc again.